### PR TITLE
new mprocTest version

### DIFF
--- a/modelParameters/mprocTest.txt
+++ b/modelParameters/mprocTest.txt
@@ -1,6 +1,4 @@
 ASSESSCLASS HCR FREF_TYP FREF_PAR0 FREF_PAR1 BREF_TYP BREF_PAR0 BREF_PAR1 RFUN_NM RPInt ImplementationClass LandZero CatchZero EconType
-CAA simplethresh FmsySim -30 -1 SIM -30 -1 hindcastMean 1 Economic TRUE TRUE Multi
-CAA simplethresh FmsySim 30 NA SIM 30 NA forecast 1 Economic TRUE TRUE Single
 CAA slide YPR 0.1 NA SIM 10 NA forecast 5 StandardFisheries NA NA NA
 CAA constF SPR 0.5 NA SIM -15 -3 hindcastMean 3 StandardFisheries NA NA NA
 CAA constF SPR 0.1 NA SIM 12 NA forecast 2 StandardFisheries NA NA NA


### PR DESCRIPTION
Deleted economic model entries in mprocTest.  I guess we will have to test those locally only ... they won't run on the HPCC because we don't have all confidential data up there...probably could have included an if() statement that checks for existence of those files and skips those MPs if they aren't there ... but I didn't!

Testing on HPCC now and seems to be running so I'm just going to create the pull request and guess that all will be good with this branch.