### PR TITLE
switch logical definition

### DIFF
--- a/processes/runSim.R
+++ b/processes/runSim.R
@@ -9,7 +9,7 @@ source('processes/runSetup.R')
 # if on local machine (i.e., not hpcc) must compile the tmb code
 # (HPCC runs have a separate call to compile this code). Keep out of
 # runSetup.R because it is really a separate process on the HPCC.
-if(runClass != 'HPCC'){
+if(runClass == 'local'){
   source('processes/runPre.R', local=ifelse(exists('plotFlag'), TRUE, FALSE))
 }
 


### PR DESCRIPTION
``runClass'' is set in [get_runinfo.R ](https://github.com/lkerr/groundfish-MSE/blob/Dev/processes/get_runinfo.R).  

It was initially designed to when there were only two possible values for runClass (local and HPCC).

The economic model runs on something that is neither local nor a server -- see [here](https://github.com/lkerr/groundfish-MSE/blob/EconOnly2/processes/get_runinfo.R). So, I'm getting a little tripped up by this logical. 

switching this to 
```
if(runClass == 'local')
```
should not pose any problems.